### PR TITLE
Update versions in libs/widget-libs/package.json

### DIFF
--- a/libs/widget-libs/package.json
+++ b/libs/widget-libs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databraid/transit-widget",
-  "version": "1.0.19",
+  "version": "1.0.23",
   "description": "",
   "main": "index.js",
   "files": [
@@ -27,15 +27,15 @@
   "dependencies": {
     "enzyme-to-json": "1.5.1",
     "prop-types": "15.5.10",
-    "react-places-autocomplete": "5.3.2",
+    "react": "15.6.1",
+    "react-dom": "15.6.1",
+    "react-places-autocomplete": "5.4.2",
+    "react-redux": "5.0.5",
+    "redux": "3.7.2",
     "redux-form": "7.0.3",
     "redux-logger": "3.0.6",
     "redux-mock-store": "1.2.3",
-    "semantic-ui-react": "0.71.3",
-    "react": "15.6.1",
-    "react-dom": "15.6.1",
-    "react-redux": "5.0.5",
-    "redux": "3.7.2",
-    "redux-thunk": "2.2.0"
+    "redux-thunk": "2.2.0",
+    "semantic-ui-react": "0.71.3"
   }
 }


### PR DESCRIPTION
I updated the version for react-places-autocomplete and published the npm module. The google logo is now displayed as required by the EULA. The widget module version is now at 1.0.23.